### PR TITLE
Display touch coordinates for debugging

### DIFF
--- a/remote-control.yaml
+++ b/remote-control.yaml
@@ -126,6 +126,12 @@ touchscreen:
       swap_xy: true
       mirror_y: true
     on_touch:
+      - lvgl.label.update:
+          id: lbl_touch
+          text: !lambda |-
+            char buf[32];
+            snprintf(buf, sizeof(buf), "%d,%d", touch.x, touch.y);
+            return std::string(buf);
       - mqtt.publish_json:
           topic: tele/${dev_topic}/touch
           payload: |-
@@ -229,6 +235,15 @@ lvgl:
             text: "Home Controls"
             align: TOP_MID
             y: 8
+            text_color: 0xFFFFFF
+
+        # Touch debug label
+        - label:
+            id: lbl_touch
+            text: ""
+            align: TOP_LEFT
+            x: 5
+            y: 5
             text_color: 0xFFFFFF
 
         # ---- Left column (4 buttons) ----


### PR DESCRIPTION
## Summary
- Add LVGL label to display touch coordinates on screen
- Update GT911 touchscreen handler to update debug label for each touch and publish coordinates

## Testing
- `esphome --version` *(fails: command not found)*
- `pip install esphome==2024.6.0` *(aborted: installation cancelled due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68acfe8c61fc832bad1680c2f96b00fa