### PR TITLE
Add touch panel scan config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Gitignore settings for ESPHome
+# This is an example and may include too much for your use-case.
+# You can modify this file to suit your needs.
+/.esphome/
+/secrets.yaml

--- a/touchpanel-scan.yaml
+++ b/touchpanel-scan.yaml
@@ -1,0 +1,97 @@
+substitutions:
+  friendly_name: Guition Display
+  dev_topic: esp32-c3-35-inch-display
+
+esphome:
+  name: esp32-c3-35-inch-display
+  friendly_name: ESP32-C3 3.5 inch Display
+  platformio_options:
+    upload_speed: 921600
+    board_build.flash_mode: dio
+    board_build.f_flash: 80000000L
+    board_build.f_cpu: 240000000L
+
+esp32:
+  board: esp32-s3-devkitc-1
+  flash_size: 16MB
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240: "y"
+      CONFIG_ESP32S3_DATA_CACHE_64KB: "y"
+      CONFIG_ESP32S3_DATA_CACHE_LINE_64B: "y"
+      CONFIG_SPIRAM_FETCH_INSTRUCTIONS: "y"
+      CONFIG_SPIRAM_RODATA: "y"
+
+psram:
+  mode: octal
+  speed: 80MHz
+
+logger:
+  baud_rate: 921600
+  level: DEBUG
+
+api:
+  encryption:
+    key: "zCbqpKMFr1E/T+n7OM26ggGNnIfVMToeC7e0Ue9xeJ4="
+
+mqtt:
+  broker: !secret mqtt_broker
+  username: !secret mqtt_user
+  password: !secret mqtt_pass
+  topic_prefix: ${dev_topic}
+  discovery: false
+
+ota:
+  - platform: esphome
+    password: "55ea0f7bcc25fa0433a43dfaf0009751"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "Esp32-C3-35-Inch-Display"
+    password: "KTWqn606IwU5"
+
+captive_portal:
+
+spi:
+  id: display_qspi
+  type: quad
+  clk_pin: 47
+  data_pins: [21, 48, 40, 39]
+
+output:
+  - platform: ledc
+    pin: GPIO1
+    id: backlight
+
+light:
+  - platform: monochromatic
+    id: backlight_light
+    output: backlight
+    name: "Backlight"
+    restore_mode: ALWAYS_ON
+
+display:
+  - platform: qspi_dbi
+    model: axs15231
+    data_rate: 40MHz
+    id: my_display
+    spi_id: display_qspi
+    dimensions:
+      height: 480
+      width: 320
+    cs_pin: 45
+    rotation: 90
+    auto_clear_enabled: false
+    update_interval: never
+
+# I2C bus used by the touch controller. "scan: true" logs any detected
+# I2C device addresses on this bus at boot, helping identify the touch IC.
+i2c:
+  id: touchscreen_bus
+  sda: 4
+  scl: 8
+  frequency: 400kHz
+  scan: true


### PR DESCRIPTION
## Summary
- add `touchpanel-scan.yaml` to probe I2C bus for touchscreen detection
- add `.gitignore` to avoid checking in secrets and build artifacts

## Testing
- `esphome config touchpanel-scan.yaml`
- `esphome compile touchpanel-scan.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68ad00ef4da4832bb0b6e0feac083323