### PR TITLE
docs: correct board model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# JC4832W535-3.5inch-HA-remote
-JC4832W535 3.5inch HA remote
+# JC3248W535-3.5inch-HA-remote
+Configuration for the JC3248W535 3.5-inch Home Assistant remote.
+Note: earlier revisions referred to the board as JC4832W535.

--- a/remote-control.yaml
+++ b/remote-control.yaml
@@ -115,7 +115,8 @@ i2c:
   frequency: 400kHz
   scan: true                 # watch logs for detected addresses
 
-# Goodix GT911 (common on JC4832W535). Update address if logs show a different value (e.g. 0x14).
+# Goodix GT911 touch controller (common on JC3248W535).
+# Update address if logs show a different value (e.g., 0x14).
 touchscreen:
   - platform: gt911
     id: my_touch


### PR DESCRIPTION
## Summary
- Clarify that the display module is JC3248W535 rather than JC4832W535
- Update touchscreen comment to use the correct model name

## Testing
- `yamllint remote-control.yaml touchpanel-scan.yaml` *(fails: line-length, braces, document-start)*

------
https://chatgpt.com/codex/tasks/task_e_68ad062626b8832b88cd7fdd413ba40c