### PR TITLE
Add debug logging for touch panel

### DIFF
--- a/remote-control.yaml
+++ b/remote-control.yaml
@@ -29,7 +29,7 @@ psram:
 
 logger:
   baud_rate: 921600
-  level: INFO
+  level: DEBUG
 
 # Home Assistant native API (needed for homeassistant.service & HA state mirrors)
 api:
@@ -113,7 +113,7 @@ i2c:
   sda: 4
   scl: 8
   frequency: 400kHz
-  scan: true                 # watch logs for detected addresses
+  scan: false                # 0x3B device found during scan
 
 # Goodix GT911 touch controller (common on JC3248W535).
 # Update address if logs show a different value (e.g., 0x14).
@@ -127,6 +127,10 @@ touchscreen:
       swap_xy: true
       mirror_y: true
     on_touch:
+      - logger.log:
+          format: "Touch: (%d,%d)"
+          args: [touch.x, touch.y]
+          level: DEBUG
       - lvgl.label.update:
           id: lbl_touch
           text: !lambda |-


### PR DESCRIPTION
## Summary
- set logger level to DEBUG
- disable I2C bus scanning now that GT911 responds at 0x3B
- log touch coordinates on each event

## Testing
- `esphome config remote-control.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68ad0d4e098c832b90fbf983d76cafdc