### PR TITLE
Remove unused GT911 interrupt pin from remote control config

### DIFF
--- a/remote-control.yaml
+++ b/remote-control.yaml
@@ -122,7 +122,6 @@ touchscreen:
     id: my_touch
     i2c_id: touchscreen_bus
     address: 0x3B
-    interrupt_pin: 3
     transform:
       swap_xy: true
       mirror_y: true


### PR DESCRIPTION
## Summary
- remove interrupt pin configuration from GT911 touchscreen since GPIO3 isn't connected

## Testing
- `esphome config remote-control.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68ad10e3a698832b9c071724661627f3