### PR TITLE
feat: color remote buttons by device state

### DIFF
--- a/remote-control.yaml
+++ b/remote-control.yaml
@@ -182,6 +182,12 @@ text_sensor:
             if (x == "on")  return std::string("Roof Lights (ON)");
             if (x == "off") return std::string("Roof Lights (OFF)");
             return std::string("Roof Lights (") + x + ")";
+      - lvgl.button.update:
+          id: btn_roof
+          bg_color: !lambda |-
+            if (x == "on")  return lv_color_hex(0xffc107);
+            if (x == "off") return lv_color_hex(0x2d87c8);
+            return lv_color_hex(0x808080);
 
   - platform: homeassistant
     id: ts_bed2
@@ -193,6 +199,12 @@ text_sensor:
             if (x == "on")  return std::string("Bedroom 2 (ON)");
             if (x == "off") return std::string("Bedroom 2 (OFF)");
             return std::string("Bedroom 2 (") + x + ")";
+      - lvgl.button.update:
+          id: btn_bed2
+          bg_color: !lambda |-
+            if (x == "on")  return lv_color_hex(0xffc107);
+            if (x == "off") return lv_color_hex(0x2d87c8);
+            return lv_color_hex(0x808080);
 
   - platform: homeassistant
     id: ts_toilet3
@@ -204,6 +216,12 @@ text_sensor:
             if (x == "on")  return std::string("Toilet (ON)");
             if (x == "off") return std::string("Toilet (OFF)");
             return std::string("Toilet (") + x + ")";
+      - lvgl.button.update:
+          id: btn_toilet3
+          bg_color: !lambda |-
+            if (x == "on")  return lv_color_hex(0xffc107);
+            if (x == "off") return lv_color_hex(0x2d87c8);
+            return lv_color_hex(0x808080);
 
   - platform: homeassistant
     id: ts_shelly
@@ -215,6 +233,12 @@ text_sensor:
             if (x == "on")  return std::string("Shelly1 (ON)");
             if (x == "off") return std::string("Shelly1 (OFF)");
             return std::string("Shelly1 (") + x + ")";
+      - lvgl.button.update:
+          id: btn_shelly
+          bg_color: !lambda |-
+            if (x == "on")  return lv_color_hex(0xffc107);
+            if (x == "off") return lv_color_hex(0x2d87c8);
+            return lv_color_hex(0x808080);
 
   - platform: homeassistant
     id: ts_flood
@@ -226,6 +250,12 @@ text_sensor:
             if (x == "on")  return std::string("RGB Floodlight (ON)");
             if (x == "off") return std::string("RGB Floodlight (OFF)");
             return std::string("RGB Floodlight (") + x + ")";
+      - lvgl.button.update:
+          id: btn_flood
+          bg_color: !lambda |-
+            if (x == "on")  return lv_color_hex(0xffc107);
+            if (x == "off") return lv_color_hex(0x2d87c8);
+            return lv_color_hex(0x808080);
 
 # ---------- LVGL UI (with working props) ----------
 lvgl:
@@ -269,6 +299,7 @@ lvgl:
             align: TOP_LEFT
             x: 10
             y: 36
+            bg_color: 0x808080
             on_click:
               - homeassistant.service:
                   service: homeassistant.toggle
@@ -289,6 +320,7 @@ lvgl:
             align: TOP_LEFT
             x: 10
             y: 106
+            bg_color: 0x808080
             on_click:
               - homeassistant.service:
                   service: homeassistant.toggle
@@ -309,6 +341,7 @@ lvgl:
             align: TOP_LEFT
             x: 10
             y: 176
+            bg_color: 0x808080
             on_click:
               - homeassistant.service:
                   service: homeassistant.toggle
@@ -329,6 +362,7 @@ lvgl:
             align: TOP_LEFT
             x: 10
             y: 246
+            bg_color: 0x808080
             on_click:
               - homeassistant.service:
                   service: homeassistant.toggle
@@ -350,6 +384,7 @@ lvgl:
             align: TOP_LEFT
             x: 250
             y: 36
+            bg_color: 0x808080
             on_click:
               - homeassistant.service:
                   service: homeassistant.toggle
@@ -370,6 +405,7 @@ lvgl:
             align: TOP_LEFT
             x: 250
             y: 106
+            bg_color: 0x808080
             on_click:
               - homeassistant.service:
                   service: homeassistant.toggle
@@ -390,6 +426,7 @@ lvgl:
             align: TOP_LEFT
             x: 250
             y: 176
+            bg_color: 0x808080
             on_click:
               - homeassistant.service:
                   service: homeassistant.toggle
@@ -410,6 +447,7 @@ lvgl:
             align: TOP_LEFT
             x: 250
             y: 246
+            bg_color: 0x808080
             on_click:
               - homeassistant.service:
                   service: homeassistant.toggle


### PR DESCRIPTION
## Summary
- color remote buttons orange when their device is on, blue when off, and grey otherwise
- default all buttons to grey, including spares

## Testing
- `yamllint remote-control.yaml` *(fails: line-length and brace style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2dd5d418832b9e9788825aafed5e