### PR TITLE
Display clock in 12-hour format

### DIFF
--- a/remote-control.yaml
+++ b/remote-control.yaml
@@ -100,8 +100,8 @@ time:
               id: lbl_clock
               text: !lambda |-
                 auto t = id(homeassistant_time).now();
-                char buf[6];
-                snprintf(buf, sizeof(buf), "%02d:%02d", t.hour, t.minute);
+                char buf[9];
+                t.strftime(buf, sizeof(buf), "%I:%M %p");
                 return std::string(buf);
 
 # ---------- Display (QSPI DBI) ----------


### PR DESCRIPTION
## Summary
- show clock using 12-hour format with AM/PM indicator

## Testing
- `esphome config remote-control.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68ad8dafb3c4832ba8c15486563e6e79