### PR TITLE
Fix include indentation in UI pages

### DIFF
--- a/ui/house_page.yaml
+++ b/ui/house_page.yaml
@@ -42,7 +42,8 @@ lvgl:
             text_color: 0xFFFFFF
 
         # Row 1
-        - !include button_template.yaml
+        - !include
+          file: button_template.yaml
           vars:
             btn_id: btn_house_kitchen
             label_id: lbl_house_kitchen
@@ -52,7 +53,8 @@ lvgl:
             y_pos: '36'
             width: '140'
             height: '60'
-        - !include button_template.yaml
+        - !include
+          file: button_template.yaml
           vars:
             btn_id: btn_house_bedroom
             label_id: lbl_house_bedroom
@@ -62,7 +64,8 @@ lvgl:
             y_pos: '36'
             width: '140'
             height: '60'
-        - !include button_template.yaml
+        - !include
+          file: button_template.yaml
           vars:
             btn_id: btn_house_toilet
             label_id: lbl_house_toilet
@@ -74,7 +77,8 @@ lvgl:
             height: '60'
 
         # Row 2
-        - !include button_template.yaml
+        - !include
+          file: button_template.yaml
           vars:
             btn_id: btn_house_porch
             label_id: lbl_house_porch
@@ -84,7 +88,8 @@ lvgl:
             y_pos: '116'
             width: '140'
             height: '60'
-        - !include button_template.yaml
+        - !include
+          file: button_template.yaml
           vars:
             btn_id: btn_house_north
             label_id: lbl_house_north
@@ -94,7 +99,8 @@ lvgl:
             y_pos: '116'
             width: '140'
             height: '60'
-        - !include button_template.yaml
+        - !include
+          file: button_template.yaml
           vars:
             btn_id: btn_house_bbq
             label_id: lbl_house_bbq
@@ -106,7 +112,8 @@ lvgl:
             height: '60'
 
         # Row 3
-        - !include button_template.yaml
+        - !include
+          file: button_template.yaml
           vars:
             btn_id: btn_house_west
             label_id: lbl_house_west
@@ -116,7 +123,8 @@ lvgl:
             y_pos: '196'
             width: '140'
             height: '60'
-        - !include button_template.yaml
+        - !include
+          file: button_template.yaml
           vars:
             btn_id: btn_house_west_flood
             label_id: lbl_house_west_flood
@@ -126,7 +134,8 @@ lvgl:
             y_pos: '196'
             width: '140'
             height: '60'
-        - !include button_template.yaml
+        - !include
+          file: button_template.yaml
           vars:
             btn_id: btn_house_rgb_flood
             label_id: lbl_house_rgb_flood

--- a/ui/room_page.yaml
+++ b/ui/room_page.yaml
@@ -42,7 +42,8 @@ lvgl:
             text_color: 0xFFFFFF
 
         # Buttons
-        - !include button_template.yaml
+        - !include
+          file: button_template.yaml
           vars:
             btn_id: btn_room_bedroom
             label_id: lbl_room_bedroom
@@ -52,7 +53,8 @@ lvgl:
             y_pos: '36'
             width: '220'
             height: '60'
-        - !include button_template.yaml
+        - !include
+          file: button_template.yaml
           vars:
             btn_id: btn_room_kitchen
             label_id: lbl_room_kitchen
@@ -62,7 +64,8 @@ lvgl:
             y_pos: '106'
             width: '220'
             height: '60'
-        - !include button_template.yaml
+        - !include
+          file: button_template.yaml
           vars:
             btn_id: btn_room_toilet
             label_id: lbl_room_toilet


### PR DESCRIPTION
## Summary
- fix `!include` syntax in house and room pages to use `file` and `vars`

## Testing
- `yamllint ui/house_page.yaml ui/room_page.yaml`
- `esphome config remote-control.yaml` *(fails: configuration valid but required temporary secrets file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8a08c174832bb75b66e7e7e7680a