### PR TITLE
Cancel button tap on swipe gestures

### DIFF
--- a/ui/button_template.yaml
+++ b/ui/button_template.yaml
@@ -8,14 +8,18 @@ button:
   bg_color: 0x808080
   bg_grad_color: 0x606060
   bg_grad_dir: VER
-  on_click:
-    - homeassistant.service:
-        service: homeassistant.toggle
-        data:
-          entity_id: ${entity_id}
-    - mqtt.publish:
-        topic: stat/${dev_topic}/${btn_id}
-        payload: "click"
+  on_release:
+    - if:
+        condition:
+          lambda: 'return lv_indev_get_gesture_dir(lv_indev_get_act()) == LV_DIR_NONE;'
+        then:
+          - homeassistant.service:
+              service: homeassistant.toggle
+              data:
+                entity_id: ${entity_id}
+          - mqtt.publish:
+              topic: stat/${dev_topic}/${btn_id}
+              payload: "click"
   widgets:
     - label:
         id: ${label_id}


### PR DESCRIPTION
## Summary
- Trigger Home Assistant actions only when a button touch is released
- Ignore button actions if a swipe gesture is detected before release

## Testing
- `esphome compile remote-control.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68aeb371afac832b8e595d1cade5b8f9