### PR TITLE
Update room entities and drop climate controls

### DIFF
--- a/remote-control.yaml
+++ b/remote-control.yaml
@@ -1,10 +1,9 @@
 substitutions:
   friendly_name: Guition Display
   dev_topic: esp32-c3-35-inch-display   # used for MQTT topics
-  room_light: light.kitchen_light_dimmer
-  room_temp_sensor: sensor.kitchen_temperature
-  room_climate_entity: climate.kitchen
-  room_ac_zone_switch: switch.kitchen_ac_zone
+  room_light: switch.bedroom_light_switch_2
+  room_temp_sensor: sensor.temperature_kitchen_temperature
+  room_ac_zone_switch: switch.zone_6_2
 
 external_components:
   - source: github://esphome/esphome@2025.7.1
@@ -454,15 +453,6 @@ sensor:
       - lvgl.label.update:
           id: lbl_temp
           text: !lambda 'char buf[16]; snprintf(buf, sizeof(buf), "Temp: %.1f°C", x); return std::string(buf);'
-  - platform: homeassistant
-    id: room_setpoint
-    entity_id: ${room_climate_entity}
-    attribute: temperature
-    on_value:
-      - lvgl.label.update:
-          id: lbl_set_temp
-          text: !lambda 'char buf[16]; snprintf(buf, sizeof(buf), "Set: %.1f°C", x); return std::string(buf);'
-
 # ---------- LVGL UI (with working props) ----------
 lvgl:
   displays:

--- a/ui/room_page.yaml
+++ b/ui/room_page.yaml
@@ -81,50 +81,6 @@ lvgl:
             y: 140
             text_color: 0xFFFFFF
 
-        # Desired temperature
-        - label:
-            id: lbl_set_temp
-            text: "Set: --"
-            align: TOP_LEFT
-            x: 10
-            y: 170
-            text_color: 0xFFFFFF
-
-        # Temperature controls
-        - button:
-            id: btn_temp_down
-            width: 40
-            height: 40
-            align: TOP_LEFT
-            x: 200
-            y: 160
-            on_release:
-              - homeassistant.service:
-                  service: climate.set_temperature
-                  data:
-                    entity_id: ${room_climate_entity}
-                    temperature: !lambda 'return id(room_setpoint).state - 1;'
-            widgets:
-              - label:
-                  text: "-"
-                  align: CENTER
-        - button:
-            id: btn_temp_up
-            width: 40
-            height: 40
-            align: TOP_LEFT
-            x: 250
-            y: 160
-            on_release:
-              - homeassistant.service:
-                  service: climate.set_temperature
-                  data:
-                    entity_id: ${room_climate_entity}
-                    temperature: !lambda 'return id(room_setpoint).state + 1;'
-            widgets:
-              - label:
-                  text: "+"
-                  align: CENTER
 
         # AC zone control
         - button:
@@ -144,4 +100,3 @@ lvgl:
                   id: lbl_zone
                   text: "Zone"
                   align: CENTER
-


### PR DESCRIPTION
## Summary
- update room substitutions to bedroom light, kitchen temperature sensor, and AC zone switch
- remove unused climate setpoint and related UI temperature controls

## Testing
- `yamllint remote-control.yaml ui/room_page.yaml ui/house_page.yaml` *(fails: line-length and comment warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aef1217390832b86b3be28664e5b61