### PR TITLE
Add overview page with clock and controls

### DIFF
--- a/remote-control.yaml
+++ b/remote-control.yaml
@@ -24,7 +24,7 @@ esphome:
     board_build.f_cpu: 240000000L
   on_boot:
     then:
-      - lvgl.page.show: room_page
+      - lvgl.page.show: overview_page
 
 esp32:
   board: esp32-s3-devkitc-1
@@ -80,6 +80,11 @@ mqtt:
               lambda: 'return x.containsKey("page") && x["page"].as<std::string>() == "house";'
             then:
               - lvgl.page.show: house_page
+        - if:
+            condition:
+              lambda: 'return x.containsKey("page") && x["page"].as<std::string>() == "overview";'
+            then:
+              - lvgl.page.show: overview_page
 
 ota:
   - platform: esphome
@@ -134,6 +139,20 @@ time:
                 char buf[9];
                 t.strftime(buf, sizeof(buf), "%I:%M %p");
                 return std::string(buf);
+          - lvgl.label.update:
+              id: lbl_clock_o
+              text: !lambda |-
+                auto t = id(homeassistant_time).now();
+                char buf[6];
+                t.strftime(buf, sizeof(buf), "%I:%M");
+                return std::string(buf);
+          - lvgl.label.update:
+              id: lbl_day_o
+              text: !lambda |-
+                auto t = id(homeassistant_time).now();
+                char buf[10];
+                t.strftime(buf, sizeof(buf), "%A");
+                return std::string(buf);
 
 text_sensor:
   - platform: homeassistant
@@ -147,6 +166,17 @@ text_sensor:
             return std::string("Kitchen (") + x + ")";
       - lvgl.button.update:
           id: btn_house_kitchen
+          bg_color: !lambda |-
+            if (x == "on")  return lv_color_hex(0xffc107);
+            if (x == "off") return lv_color_hex(0x2d87c8);
+            return lv_color_hex(0x808080);
+          bg_grad_color: !lambda |-
+            if (x == "on")  return lv_color_hex(0xdfa100);
+            if (x == "off") return lv_color_hex(0x1973b4);
+            return lv_color_hex(0x606060);
+          bg_grad_dir: VER
+      - lvgl.button.update:
+          id: btn_overview_light
           bg_color: !lambda |-
             if (x == "on")  return lv_color_hex(0xffc107);
             if (x == "off") return lv_color_hex(0x2d87c8);
@@ -328,6 +358,11 @@ text_sensor:
           bg_color: !lambda 'return x == "on" ? lv_color_hex(0xffc107) : lv_color_hex(0x2d87c8);'
           bg_grad_color: !lambda 'return x == "on" ? lv_color_hex(0xdfa100) : lv_color_hex(0x1973b4);'
           bg_grad_dir: VER
+      - lvgl.button.update:
+          id: btn_overview_fan
+          bg_color: !lambda 'return x == "on" ? lv_color_hex(0xffc107) : lv_color_hex(0x2d87c8);'
+          bg_grad_color: !lambda 'return x == "on" ? lv_color_hex(0xdfa100) : lv_color_hex(0x1973b4);'
+          bg_grad_dir: VER
 
 # ---------- Display (QSPI DBI) ----------
 spi:
@@ -447,12 +482,23 @@ sensor:
           id: sld_light
           value: !lambda 'return x * 100.0 / 255.0;'
   - platform: homeassistant
+    id: kitchen_light_level
+    entity_id: light.kitchen_light_dimmer
+    attribute: brightness
+    on_value:
+      - lvgl.slider.update:
+          id: sld_overview_light
+          value: !lambda 'return x * 100.0 / 255.0;'
+  - platform: homeassistant
     id: room_temperature
     entity_id: ${room_temp_sensor}
     on_value:
       - lvgl.label.update:
           id: lbl_temp
           text: !lambda 'char buf[16]; snprintf(buf, sizeof(buf), "Temp: %.1f°C", x); return std::string(buf);'
+      - lvgl.label.update:
+          id: lbl_temp_o
+          text: !lambda 'char buf[8]; snprintf(buf, sizeof(buf), "%.1f°C", x); return std::string(buf);'
 # ---------- LVGL UI (with working props) ----------
 lvgl:
   displays:
@@ -464,3 +510,4 @@ lvgl:
 packages:
   room_page: !include ui/room_page.yaml
   house_page: !include ui/house_page.yaml
+  overview_page: !include ui/overview_page.yaml

--- a/ui/overview_page.yaml
+++ b/ui/overview_page.yaml
@@ -1,0 +1,123 @@
+lvgl:
+  pages:
+    - id: overview_page
+      on_swipe_left:
+        - lvgl.page.show: house_page
+      on_swipe_right:
+        - lvgl.page.show: room_page
+      widgets:
+        # Background
+        - obj:
+            width: 484
+            height: 324
+            align: CENTER
+            x: 0
+            y: 0
+            bg_opa: 100%
+            bg_color: 0x000000
+            bg_grad_color: 0x000000
+            bg_grad_dir: VER
+            border_width: 0
+            border_color: 0x000000
+
+        # Clock
+        - label:
+            id: lbl_clock_o
+            text: "12:00"
+            align: TOP_MID
+            y: 10
+            text_color: 0xFFFFFF
+            text_font: font_clock
+        - label:
+            id: lbl_day_o
+            text: "Monday"
+            align: TOP_MID
+            y: 70
+            text_color: 0xFFFFFF
+
+        # Light button
+        - button:
+            id: btn_overview_light
+            width: 100
+            height: 100
+            align: TOP_LEFT
+            x: 20
+            y: 110
+            bg_color: 0x808080
+            bg_grad_color: 0x606060
+            bg_grad_dir: VER
+            on_release:
+              - if:
+                  condition:
+                    lambda: 'return lv_indev_get_gesture_dir(lv_indev_get_act()) == LV_DIR_NONE;'
+                  then:
+                    - homeassistant.service:
+                        service: homeassistant.toggle
+                        data:
+                          entity_id: light.kitchen_light_dimmer
+            widgets:
+              - label:
+                  text: LV_SYMBOL_BULB
+                  align: CENTER
+                  text_color: 0xFFFFFF
+                  text_font: font_clock
+
+        # Fan button
+        - button:
+            id: btn_overview_fan
+            width: 100
+            height: 100
+            align: TOP_RIGHT
+            x: -20
+            y: 110
+            bg_color: 0x808080
+            bg_grad_color: 0x606060
+            bg_grad_dir: VER
+            on_release:
+              - if:
+                  condition:
+                    lambda: 'return lv_indev_get_gesture_dir(lv_indev_get_act()) == LV_DIR_NONE;'
+                  then:
+                    - homeassistant.service:
+                        service: homeassistant.toggle
+                        data:
+                          entity_id: switch.zone_5_2
+            widgets:
+              - label:
+                  text: LV_SYMBOL_REFRESH
+                  align: CENTER
+                  text_color: 0xFFFFFF
+                  text_font: font_clock
+
+        # Brightness slider
+        - slider:
+            id: sld_overview_light
+            width: 300
+            height: 40
+            align: TOP_MID
+            y: 230
+            min_value: 0
+            max_value: 100
+            on_value:
+              - if:
+                  condition:
+                    lambda: 'return x == 0;'
+                  then:
+                    - homeassistant.service:
+                        service: light.turn_off
+                        data:
+                          entity_id: light.kitchen_light_dimmer
+                  else:
+                    - homeassistant.service:
+                        service: light.turn_on
+                        data:
+                          entity_id: light.kitchen_light_dimmer
+                          brightness_pct: !lambda 'return x;'
+
+        # Temperature
+        - label:
+            id: lbl_temp_o
+            text: "--°C"
+            align: BOTTOM_MID
+            y: -10
+            text_color: 0xFFFFFF


### PR DESCRIPTION
## Summary
- Add modern "overview" page with light and fan controls, brightness slider, clock/day display and temperature readout
- Wire page into startup and MQTT, and update entity sensors

## Testing
- `esphome compile remote-control.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68b00994f1f8832b89d23bc84f700740