### PR TITLE
Fix page navigation order

### DIFF
--- a/ui/house_page.yaml
+++ b/ui/house_page.yaml
@@ -2,7 +2,7 @@ lvgl:
   pages:
     - id: house_page
       on_swipe_left:
-        - lvgl.page.show: room_page
+        - lvgl.page.show: overview_page
       on_swipe_right:
         - lvgl.page.show: room_page
       widgets:

--- a/ui/overview_page.yaml
+++ b/ui/overview_page.yaml
@@ -2,9 +2,9 @@ lvgl:
   pages:
     - id: overview_page
       on_swipe_left:
-        - lvgl.page.show: house_page
-      on_swipe_right:
         - lvgl.page.show: room_page
+      on_swipe_right:
+        - lvgl.page.show: house_page
       widgets:
         # Background
         - obj:

--- a/ui/room_page.yaml
+++ b/ui/room_page.yaml
@@ -4,7 +4,7 @@ lvgl:
       on_swipe_left:
         - lvgl.page.show: house_page
       on_swipe_right:
-        - lvgl.page.show: house_page
+        - lvgl.page.show: overview_page
       widgets:
         # Background
         - obj:


### PR DESCRIPTION
## Summary
- Link overview, room, and house pages in a circular swipe chain

## Testing
- `esphome config remote-control.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68b021e43898832b899cb01d0d015ef2